### PR TITLE
fixed nav links that don't have sub-menus from having right arrow

### DIFF
--- a/_includes/navigation_link.html
+++ b/_includes/navigation_link.html
@@ -34,7 +34,7 @@
 	{% if include.link.side == "left" %}<li class="divider"></li>{% endif %}
 {% else %}
 	{% if include.link.side == "right" %}<li class="divider"></li>{% endif %}
-	<li class="has-dropdown{% if page_url == link_url or page_url contains link_url and link_url != '/' %} active{% endif %}">
+	<li class="{% if include.link.dropdown %}has-dropdown {% endif %}{% if page_url == link_url or page_url contains link_url and link_url != '/' %} active{% endif %}">
 		{{ linkHTML }}
 		<ul class="dropdown">
 			{% for sublink in include.link.dropdown %}


### PR DESCRIPTION
added if statement around has-dropdown so If the link does not have a dropdown attribute then the has-dropdown css class is not added.  